### PR TITLE
Missing comma

### DIFF
--- a/src/main/scala/com/gjsduarte/DatadogAppender.scala
+++ b/src/main/scala/com/gjsduarte/DatadogAppender.scala
@@ -120,7 +120,7 @@ class DatadogAppender extends SocketAppender with PreSerializationTransformer[IL
        |  "service": "${escape(resolveValue(service))}",
        |  "source": "${escape(resolveValue(source))}",
        |  "sourcecategory": "${escape(resolveValue(sourceCategory))}",
-       |  "env": "${escape(resolveValue(environment))}"
+       |  "env": "${escape(resolveValue(environment))}",
        |  "logger.name": "${escape(event.getLoggerName)}",
        |  "logger.thread_name": "${escape(event.getThreadName)}",
        |  "level": "${event.getLevel.levelStr}",


### PR DESCRIPTION
The data is not being parsed in Datadog due to a missing comma.